### PR TITLE
chore: move table to separate components

### DIFF
--- a/__tests__/components/ServicesTable.test.js
+++ b/__tests__/components/ServicesTable.test.js
@@ -115,14 +115,14 @@ describe('ServicesTable', () => {
 
     // Should show the app label instead of the service name in the table
     expect(screen.getByText('Test App 1')).toBeInTheDocument();
-    
+
     // Verify the table cell shows the label, not the service name
     const tableRows = screen.getAllByRole('row');
-    const firstServiceRow = tableRows.find(row => 
-      row.textContent.includes('Test App 1') && row.textContent.includes('default')
+    const firstServiceRow = tableRows.find(
+      (row) => row.textContent.includes('Test App 1') && row.textContent.includes('default')
     );
     expect(firstServiceRow).toBeInTheDocument();
-    
+
     // Verify the name column shows the label, not the service name
     const nameCell = firstServiceRow.querySelector('td:first-child');
     expect(nameCell).toHaveTextContent('Test App 1');
@@ -135,11 +135,11 @@ describe('ServicesTable', () => {
     // Should show the service name in the table when no app label is present
     // Check the table cell specifically, not the ServiceLink
     const tableRows = screen.getAllByRole('row');
-    const secondServiceRow = tableRows.find(row => 
-      row.textContent.includes('test-service-2') && row.textContent.includes('kube-system')
+    const secondServiceRow = tableRows.find(
+      (row) => row.textContent.includes('test-service-2') && row.textContent.includes('kube-system')
     );
     expect(secondServiceRow).toBeInTheDocument();
-    
+
     // Verify the service name appears in the name column (first td after potential header)
     const nameCell = secondServiceRow.querySelector('td:first-child');
     expect(nameCell).toHaveTextContent('test-service-2');

--- a/__tests__/components/ServicesTable.test.js
+++ b/__tests__/components/ServicesTable.test.js
@@ -1,0 +1,156 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ServicesTable from '../../components/ServicesTable';
+
+// Mock the ServiceLink component
+jest.mock('../../components/ServiceLink', () => {
+  return function MockServiceLink({ service }) {
+    return <div data-testid="service-link">{service.metadata.name}</div>;
+  };
+});
+
+describe('ServicesTable', () => {
+  const mockServices = [
+    {
+      metadata: {
+        name: 'test-service-1',
+        namespace: 'default',
+        labels: { 'app.kubernetes.io/name': 'Test App 1' },
+      },
+      spec: {
+        type: 'ClusterIP',
+        clusterIP: '10.0.0.1',
+        ports: [
+          { port: 80, protocol: 'TCP' },
+          { port: 443, protocol: 'TCP', nodePort: 30044 },
+        ],
+      },
+    },
+    {
+      metadata: {
+        name: 'test-service-2',
+        namespace: 'kube-system',
+        labels: {},
+      },
+      spec: {
+        type: 'NodePort',
+        clusterIP: '10.0.0.2',
+        ports: [{ port: 8080, protocol: 'TCP', nodePort: 30080 }],
+      },
+    },
+  ];
+
+  const mockNodes = [
+    {
+      addresses: [{ type: 'InternalIP', address: '192.168.1.100' }],
+    },
+  ];
+
+  it('renders table headers correctly', () => {
+    render(<ServicesTable services={[]} nodes={[]} loading={false} />);
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Namespace')).toBeInTheDocument();
+    expect(screen.getByText('Type')).toBeInTheDocument();
+    expect(screen.getByText('ClusterIP')).toBeInTheDocument();
+    expect(screen.getByText('Ports')).toBeInTheDocument();
+    expect(screen.getByText('Link')).toBeInTheDocument();
+  });
+
+  it('renders no services message when services array is empty and not loading', () => {
+    render(<ServicesTable services={[]} nodes={[]} loading={false} />);
+
+    expect(screen.getByText('No services loaded')).toBeInTheDocument();
+  });
+
+  it('renders services data correctly', () => {
+    render(<ServicesTable services={mockServices} nodes={mockNodes} loading={false} />);
+
+    // Check first service
+    expect(screen.getByText('Test App 1')).toBeInTheDocument();
+    expect(screen.getByText('default')).toBeInTheDocument();
+    // Use getAllByText for ClusterIP since it appears in both header and cell
+    expect(screen.getAllByText('ClusterIP')).toHaveLength(2);
+    expect(screen.getByText('10.0.0.1')).toBeInTheDocument();
+    // Use getAllByText for ports since multiple ports match the criteria
+    expect(
+      screen.getAllByText((content) => {
+        return content.includes('80') && content.includes('TCP');
+      })
+    ).toHaveLength(2); // Both 80/TCP and 8080/TCP match
+    expect(
+      screen.getByText((content) => {
+        return (
+          content.includes('443') && content.includes('TCP') && content.includes('NodePort: 30044')
+        );
+      })
+    ).toBeInTheDocument();
+
+    // Check second service
+    expect(screen.getAllByText('test-service-2')).toHaveLength(2); // In table cell and ServiceLink
+    expect(screen.getByText('kube-system')).toBeInTheDocument();
+    expect(screen.getByText('NodePort')).toBeInTheDocument();
+    expect(screen.getByText('10.0.0.2')).toBeInTheDocument();
+    expect(
+      screen.getByText((content) => {
+        return (
+          content.includes('8080') && content.includes('TCP') && content.includes('NodePort: 30080')
+        );
+      })
+    ).toBeInTheDocument();
+
+    // Check service links are rendered
+    expect(screen.getAllByTestId('service-link')).toHaveLength(2);
+  });
+
+  it('does not show no services message when loading', () => {
+    render(<ServicesTable services={[]} nodes={[]} loading={true} />);
+
+    expect(screen.queryByText('No services loaded')).not.toBeInTheDocument();
+  });
+
+  it('renders services with app.kubernetes.io/name label when available', () => {
+    render(<ServicesTable services={mockServices} nodes={mockNodes} loading={false} />);
+
+    // Should show the app label instead of the service name in the table
+    expect(screen.getByText('Test App 1')).toBeInTheDocument();
+    // Check that the service name appears in the table cell (not in the ServiceLink)
+    const nameCells = screen.getAllByText('test-service-1');
+    expect(nameCells.length).toBeGreaterThan(0);
+  });
+
+  it('falls back to service name when app.kubernetes.io/name label is not present', () => {
+    render(<ServicesTable services={mockServices} nodes={mockNodes} loading={false} />);
+
+    // Should show the service name when no app label is present
+    // Use getAllByText since the service name appears in both the table and the ServiceLink mock
+    expect(screen.getAllByText('test-service-2')).toHaveLength(2);
+  });
+
+  it('renders multiple ports correctly with separators', () => {
+    const serviceWithMultiplePorts = [mockServices[0]]; // First service has multiple ports
+    render(<ServicesTable services={serviceWithMultiplePorts} nodes={mockNodes} loading={false} />);
+
+    // Check that both ports are rendered using flexible matching
+    expect(
+      screen.getByText((content) => {
+        return content.includes('80') && content.includes('TCP');
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText((content) => {
+        return (
+          content.includes('443') && content.includes('TCP') && content.includes('NodePort: 30044')
+        );
+      })
+    ).toBeInTheDocument();
+
+    // Check that the separator is present by checking for comma
+    const portsContainer = screen.getByText((content) => {
+      return content.includes('80') && content.includes('TCP');
+    }).parentElement;
+    expect(portsContainer).toBeInTheDocument();
+    expect(portsContainer.textContent).toContain(',');
+  });
+});

--- a/__tests__/components/ServicesTable.test.js
+++ b/__tests__/components/ServicesTable.test.js
@@ -115,17 +115,34 @@ describe('ServicesTable', () => {
 
     // Should show the app label instead of the service name in the table
     expect(screen.getByText('Test App 1')).toBeInTheDocument();
-    // Check that the service name appears in the table cell (not in the ServiceLink)
-    const nameCells = screen.getAllByText('test-service-1');
-    expect(nameCells.length).toBeGreaterThan(0);
+    
+    // Verify the table cell shows the label, not the service name
+    const tableRows = screen.getAllByRole('row');
+    const firstServiceRow = tableRows.find(row => 
+      row.textContent.includes('Test App 1') && row.textContent.includes('default')
+    );
+    expect(firstServiceRow).toBeInTheDocument();
+    
+    // Verify the name column shows the label, not the service name
+    const nameCell = firstServiceRow.querySelector('td:first-child');
+    expect(nameCell).toHaveTextContent('Test App 1');
+    expect(nameCell).not.toHaveTextContent('test-service-1');
   });
 
   it('falls back to service name when app.kubernetes.io/name label is not present', () => {
     render(<ServicesTable services={mockServices} nodes={mockNodes} loading={false} />);
 
-    // Should show the service name when no app label is present
-    // Use getAllByText since the service name appears in both the table and the ServiceLink mock
-    expect(screen.getAllByText('test-service-2')).toHaveLength(2);
+    // Should show the service name in the table when no app label is present
+    // Check the table cell specifically, not the ServiceLink
+    const tableRows = screen.getAllByRole('row');
+    const secondServiceRow = tableRows.find(row => 
+      row.textContent.includes('test-service-2') && row.textContent.includes('kube-system')
+    );
+    expect(secondServiceRow).toBeInTheDocument();
+    
+    // Verify the service name appears in the name column (first td after potential header)
+    const nameCell = secondServiceRow.querySelector('td:first-child');
+    expect(nameCell).toHaveTextContent('test-service-2');
   });
 
   it('renders multiple ports correctly with separators', () => {

--- a/__tests__/hooks/useServiceFilters.test.js
+++ b/__tests__/hooks/useServiceFilters.test.js
@@ -1,0 +1,450 @@
+import { renderHook, act } from '@testing-library/react';
+import { useServiceFilters } from '../../hooks/useServiceFilters';
+
+describe('useServiceFilters', () => {
+  const mockServices = [
+    {
+      metadata: {
+        name: 'web-service',
+        namespace: 'default',
+        labels: { 'app.kubernetes.io/name': 'web-app' },
+      },
+      spec: {
+        type: 'ClusterIP',
+        clusterIP: '10.0.0.1',
+        ports: [{ port: 80, protocol: 'TCP' }],
+      },
+    },
+    {
+      metadata: {
+        name: 'api-service',
+        namespace: 'default',
+        labels: { 'app.kubernetes.io/name': 'api-app' },
+      },
+      spec: {
+        type: 'NodePort',
+        clusterIP: '10.0.0.2',
+        ports: [{ port: 8080, protocol: 'TCP', nodePort: 30080 }],
+      },
+    },
+    {
+      metadata: {
+        name: 'db-service',
+        namespace: 'kube-system',
+        labels: {},
+      },
+      spec: {
+        type: 'ClusterIP',
+        clusterIP: '10.0.0.3',
+        ports: [{ port: 5432, protocol: 'TCP' }],
+      },
+    },
+    {
+      metadata: {
+        name: 'external-service',
+        namespace: 'production',
+        labels: { 'app.kubernetes.io/name': 'external-app' },
+      },
+      spec: {
+        type: 'LoadBalancer',
+        clusterIP: '10.0.0.4',
+        ports: [{ port: 443, protocol: 'TCP' }],
+      },
+    },
+  ];
+
+  beforeEach(() => {
+    // Reset any state between tests
+    jest.clearAllMocks();
+  });
+
+  describe('initial state', () => {
+    it('should return all services when no filters are applied', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      expect(result.current.filteredServices).toHaveLength(4);
+      expect(result.current.filteredServices).toEqual(mockServices);
+    });
+
+    it('should return empty array when services is empty', () => {
+      const { result } = renderHook(() => useServiceFilters([]));
+
+      expect(result.current.filteredServices).toHaveLength(0);
+      expect(result.current.availableNamespaces).toEqual([]);
+      expect(result.current.availableTypes).toEqual([]);
+    });
+
+    it('should handle null/undefined services gracefully', () => {
+      const { result: result1 } = renderHook(() => useServiceFilters(null));
+      const { result: result2 } = renderHook(() => useServiceFilters(undefined));
+
+      expect(result1.current.filteredServices).toHaveLength(0);
+      expect(result2.current.filteredServices).toHaveLength(0);
+    });
+
+    it('should extract available namespaces and types', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      expect(result.current.availableNamespaces).toEqual(['default', 'kube-system', 'production']);
+      expect(result.current.availableTypes).toEqual(['ClusterIP', 'LoadBalancer', 'NodePort']);
+    });
+  });
+
+  describe('namespace filtering', () => {
+    it('should filter by single namespace', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.setFilter('namespaces', ['default']);
+      });
+
+      expect(result.current.filteredServices).toHaveLength(2);
+      expect(result.current.filteredServices.map((s) => s.metadata.name)).toEqual([
+        'web-service',
+        'api-service',
+      ]);
+    });
+
+    it('should filter by multiple namespaces', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.setFilter('namespaces', ['default', 'kube-system']);
+      });
+
+      expect(result.current.filteredServices).toHaveLength(3);
+      expect(result.current.filteredServices.map((s) => s.metadata.name)).toEqual([
+        'web-service',
+        'api-service',
+        'db-service',
+      ]);
+    });
+
+    it('should return empty result for non-existent namespace', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.setFilter('namespaces', ['non-existent']);
+      });
+
+      expect(result.current.filteredServices).toHaveLength(0);
+    });
+
+    it('should clear namespace filter', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.setFilter('namespaces', ['default']);
+      });
+      expect(result.current.filteredServices).toHaveLength(2);
+
+      act(() => {
+        result.current.clearFilter('namespaces');
+      });
+      expect(result.current.filteredServices).toHaveLength(4);
+    });
+  });
+
+  describe('service type filtering', () => {
+    it('should filter by single service type', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.setFilter('types', ['ClusterIP']);
+      });
+
+      expect(result.current.filteredServices).toHaveLength(2);
+      expect(result.current.filteredServices.map((s) => s.metadata.name)).toEqual([
+        'web-service',
+        'db-service',
+      ]);
+    });
+
+    it('should filter by multiple service types', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.setFilter('types', ['ClusterIP', 'NodePort']);
+      });
+
+      expect(result.current.filteredServices).toHaveLength(3);
+      expect(result.current.filteredServices.map((s) => s.metadata.name)).toEqual([
+        'web-service',
+        'api-service',
+        'db-service',
+      ]);
+    });
+
+    it('should return empty result for non-existent service type', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.setFilter('types', ['ExternalName']);
+      });
+
+      expect(result.current.filteredServices).toHaveLength(0);
+    });
+  });
+
+  describe('text search filtering', () => {
+    it('should filter by service name (case-insensitive)', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.setFilter('searchText', 'WEB');
+      });
+
+      expect(result.current.filteredServices).toHaveLength(1);
+      expect(result.current.filteredServices[0].metadata.name).toBe('web-service');
+    });
+
+    it('should filter by app label (case-insensitive)', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.setFilter('searchText', 'API');
+      });
+
+      expect(result.current.filteredServices).toHaveLength(1);
+      expect(result.current.filteredServices[0].metadata.name).toBe('api-service');
+    });
+
+    it('should find services by partial name match', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.setFilter('searchText', 'service');
+      });
+
+      expect(result.current.filteredServices).toHaveLength(4); // All contain 'service'
+    });
+
+    it('should handle empty search text', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.setFilter('searchText', '');
+      });
+
+      expect(result.current.filteredServices).toHaveLength(4);
+    });
+
+    it('should handle whitespace-only search text', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.setFilter('searchText', '   ');
+      });
+
+      expect(result.current.filteredServices).toHaveLength(4);
+    });
+
+    it('should return empty result for non-matching search', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.setFilter('searchText', 'nonexistent');
+      });
+
+      expect(result.current.filteredServices).toHaveLength(0);
+    });
+  });
+
+  describe('combined filtering', () => {
+    it('should combine namespace and type filters with AND logic', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.updateFilters({
+          namespaces: ['default'],
+          types: ['ClusterIP'],
+        });
+      });
+
+      expect(result.current.filteredServices).toHaveLength(1);
+      expect(result.current.filteredServices[0].metadata.name).toBe('web-service');
+    });
+
+    it('should combine all three filter types', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.updateFilters({
+          namespaces: ['default'],
+          types: ['NodePort'],
+          searchText: 'api',
+        });
+      });
+
+      expect(result.current.filteredServices).toHaveLength(1);
+      expect(result.current.filteredServices[0].metadata.name).toBe('api-service');
+    });
+
+    it('should return empty when filters have no overlap', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.updateFilters({
+          namespaces: ['kube-system'],
+          types: ['NodePort'],
+        });
+      });
+
+      expect(result.current.filteredServices).toHaveLength(0);
+    });
+  });
+
+  describe('filter management', () => {
+    it('should clear all filters', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.updateFilters({
+          namespaces: ['default'],
+          types: ['ClusterIP'],
+          searchText: 'web',
+        });
+      });
+      expect(result.current.filteredServices).toHaveLength(1);
+
+      act(() => {
+        result.current.clearFilters();
+      });
+
+      expect(result.current.filteredServices).toHaveLength(4);
+      expect(result.current.filters).toEqual({
+        namespaces: [],
+        types: [],
+        searchText: '',
+      });
+    });
+
+    it('should update individual filters', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.setFilter('namespaces', ['default']);
+      });
+      expect(result.current.filters.namespaces).toEqual(['default']);
+
+      act(() => {
+        result.current.setFilter('types', ['NodePort']);
+      });
+      expect(result.current.filters.types).toEqual(['NodePort']);
+
+      act(() => {
+        result.current.setFilter('searchText', 'test');
+      });
+      expect(result.current.filters.searchText).toBe('test');
+    });
+  });
+
+  describe('filter statistics', () => {
+    it('should return correct statistics when no filters are applied', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      const stats = result.current.getFilterStats();
+
+      expect(stats).toEqual({
+        totalServices: 4,
+        filteredCount: 4,
+        activeFiltersCount: 0,
+        hasActiveFilters: false,
+        isFiltered: false,
+      });
+    });
+
+    it('should return correct statistics when filters are applied', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.updateFilters({
+          namespaces: ['default'],
+          types: ['ClusterIP'],
+          searchText: '',
+        });
+      });
+
+      const stats = result.current.getFilterStats();
+
+      expect(stats).toEqual({
+        totalServices: 4,
+        filteredCount: 1,
+        activeFiltersCount: 2,
+        hasActiveFilters: true,
+        isFiltered: true,
+      });
+    });
+
+    it('should count search text as active filter only when non-empty', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      act(() => {
+        result.current.setFilter('searchText', '');
+      });
+      let stats = result.current.getFilterStats();
+      expect(stats.activeFiltersCount).toBe(0);
+
+      act(() => {
+        result.current.setFilter('searchText', 'test');
+      });
+      stats = result.current.getFilterStats();
+      expect(stats.activeFiltersCount).toBe(1);
+    });
+  });
+
+  describe('service matching utility', () => {
+    it('should correctly identify if service matches current filters', () => {
+      const { result } = renderHook(() => useServiceFilters(mockServices));
+
+      const webService = mockServices[0];
+      const dbService = mockServices[2];
+
+      // No filters - all services match
+      expect(result.current.serviceMatchesFilters(webService)).toBe(true);
+      expect(result.current.serviceMatchesFilters(dbService)).toBe(true);
+
+      act(() => {
+        result.current.setFilter('namespaces', ['default']);
+      });
+
+      expect(result.current.serviceMatchesFilters(webService)).toBe(true);
+      expect(result.current.serviceMatchesFilters(dbService)).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle services with missing metadata', () => {
+      const servicesWithMissingData = [
+        { spec: { type: 'ClusterIP' } }, // Missing metadata
+        { metadata: { name: 'test' }, spec: {} }, // Missing type
+        mockServices[0], // Valid service
+      ];
+
+      const { result } = renderHook(() => useServiceFilters(servicesWithMissingData));
+
+      act(() => {
+        result.current.setFilter('namespaces', ['default']);
+      });
+
+      expect(result.current.filteredServices).toHaveLength(1);
+      expect(result.current.filteredServices[0]).toBe(mockServices[0]);
+    });
+
+    it('should handle services with missing spec', () => {
+      const servicesWithMissingSpec = [
+        { metadata: { name: 'test', namespace: 'default' } }, // Missing spec
+        mockServices[0], // Valid service
+      ];
+
+      const { result } = renderHook(() => useServiceFilters(servicesWithMissingSpec));
+
+      act(() => {
+        result.current.setFilter('types', ['ClusterIP']);
+      });
+
+      expect(result.current.filteredServices).toHaveLength(1);
+      expect(result.current.filteredServices[0]).toBe(mockServices[0]);
+    });
+  });
+});

--- a/__tests__/hooks/useServices.test.js
+++ b/__tests__/hooks/useServices.test.js
@@ -2,12 +2,9 @@ import { renderHook, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { useServices } from '../../hooks/useServices';
 
-// Mock fetch globally
-global.fetch = jest.fn();
-
 describe('useServices', () => {
   beforeEach(() => {
-    fetch.mockClear();
+    fetch.resetMocks();
   });
 
   it('should initialize with default values', () => {
@@ -27,16 +24,16 @@ describe('useServices', () => {
       },
     ];
 
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockServices,
+    fetch.mockResponseOnce(JSON.stringify(mockServices), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
     });
 
     const { result } = renderHook(() => useServices());
 
     // Call refetch within act
     await act(async () => {
-      result.current.refetch();
+      await result.current.refetch();
     });
 
     expect(result.current.loading).toBe(false);
@@ -47,16 +44,16 @@ describe('useServices', () => {
 
   it('should handle fetch error', async () => {
     const errorMessage = 'Failed to fetch services';
-    fetch.mockResolvedValueOnce({
-      ok: false,
+    fetch.mockResponseOnce('', {
       status: 500,
+      headers: { 'Content-Type': 'application/json' },
     });
 
     const { result } = renderHook(() => useServices());
 
     // Call refetch within act
     await act(async () => {
-      result.current.refetch();
+      await result.current.refetch();
     });
 
     expect(result.current.loading).toBe(false);
@@ -66,13 +63,13 @@ describe('useServices', () => {
 
   it('should handle network error', async () => {
     const errorMessage = 'Network error';
-    fetch.mockRejectedValueOnce(new Error(errorMessage));
+    fetch.mockRejectOnce(new Error(errorMessage));
 
     const { result } = renderHook(() => useServices());
 
     // Call refetch within act
     await act(async () => {
-      result.current.refetch();
+      await result.current.refetch();
     });
 
     expect(result.current.loading).toBe(false);
@@ -81,23 +78,21 @@ describe('useServices', () => {
   });
 
   it('should handle JSON parsing error', async () => {
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => {
-        throw new Error('Invalid JSON');
-      },
+    fetch.mockResponseOnce('invalid json', {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
     });
 
     const { result } = renderHook(() => useServices());
 
     // Call refetch within act
     await act(async () => {
-      result.current.refetch();
+      await result.current.refetch();
     });
 
     expect(result.current.loading).toBe(false);
     expect(result.current.services).toEqual([]);
-    expect(result.current.error).toBe('Invalid JSON');
+    expect(result.current.error).toContain('invalid json response body');
   });
 
   it('should reset error state on successful fetch after previous error', async () => {
@@ -109,29 +104,29 @@ describe('useServices', () => {
     ];
 
     // First call fails
-    fetch.mockResolvedValueOnce({
-      ok: false,
+    fetch.mockResponseOnce('', {
       status: 500,
+      headers: { 'Content-Type': 'application/json' },
     });
 
     const { result } = renderHook(() => useServices());
 
     // First refetch - should fail
     await act(async () => {
-      result.current.refetch();
+      await result.current.refetch();
     });
 
     expect(result.current.error).toBe('Failed to fetch services');
 
     // Second call succeeds
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockServices,
+    fetch.mockResponseOnce(JSON.stringify(mockServices), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
     });
 
     // Second refetch - should succeed
     await act(async () => {
-      result.current.refetch();
+      await result.current.refetch();
     });
 
     expect(result.current.services).toEqual(mockServices);
@@ -139,15 +134,15 @@ describe('useServices', () => {
   });
 
   it('should handle empty services array', async () => {
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => [],
+    fetch.mockResponseOnce(JSON.stringify([]), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
     });
 
     const { result } = renderHook(() => useServices());
 
     await act(async () => {
-      result.current.refetch();
+      await result.current.refetch();
     });
 
     expect(result.current.services).toEqual([]);
@@ -155,9 +150,9 @@ describe('useServices', () => {
   });
 
   it('should not auto-fetch on initial render', () => {
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => [],
+    fetch.mockResponseOnce(JSON.stringify([]), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
     });
 
     const { result } = renderHook(() => useServices());

--- a/__tests__/hooks/useServices.test.js
+++ b/__tests__/hooks/useServices.test.js
@@ -1,0 +1,171 @@
+import { renderHook, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useServices } from '../../hooks/useServices';
+
+// Mock fetch globally
+global.fetch = jest.fn();
+
+describe('useServices', () => {
+  beforeEach(() => {
+    fetch.mockClear();
+  });
+
+  it('should initialize with default values', () => {
+    const { result } = renderHook(() => useServices());
+
+    expect(result.current.services).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe(null);
+    expect(typeof result.current.refetch).toBe('function');
+  });
+
+  it('should fetch services successfully', async () => {
+    const mockServices = [
+      {
+        metadata: { name: 'test-service', namespace: 'default' },
+        spec: { type: 'ClusterIP', clusterIP: '10.0.0.1' },
+      },
+    ];
+
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockServices,
+    });
+
+    const { result } = renderHook(() => useServices());
+
+    // Call refetch within act
+    await act(async () => {
+      result.current.refetch();
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.services).toEqual(mockServices);
+    expect(result.current.error).toBe(null);
+    expect(fetch).toHaveBeenCalledWith('/api/services');
+  });
+
+  it('should handle fetch error', async () => {
+    const errorMessage = 'Failed to fetch services';
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    });
+
+    const { result } = renderHook(() => useServices());
+
+    // Call refetch within act
+    await act(async () => {
+      result.current.refetch();
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.services).toEqual([]);
+    expect(result.current.error).toBe(errorMessage);
+  });
+
+  it('should handle network error', async () => {
+    const errorMessage = 'Network error';
+    fetch.mockRejectedValueOnce(new Error(errorMessage));
+
+    const { result } = renderHook(() => useServices());
+
+    // Call refetch within act
+    await act(async () => {
+      result.current.refetch();
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.services).toEqual([]);
+    expect(result.current.error).toBe(errorMessage);
+  });
+
+  it('should handle JSON parsing error', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => {
+        throw new Error('Invalid JSON');
+      },
+    });
+
+    const { result } = renderHook(() => useServices());
+
+    // Call refetch within act
+    await act(async () => {
+      result.current.refetch();
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.services).toEqual([]);
+    expect(result.current.error).toBe('Invalid JSON');
+  });
+
+  it('should reset error state on successful fetch after previous error', async () => {
+    const mockServices = [
+      {
+        metadata: { name: 'test-service', namespace: 'default' },
+        spec: { type: 'ClusterIP', clusterIP: '10.0.0.1' },
+      },
+    ];
+
+    // First call fails
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    });
+
+    const { result } = renderHook(() => useServices());
+
+    // First refetch - should fail
+    await act(async () => {
+      result.current.refetch();
+    });
+
+    expect(result.current.error).toBe('Failed to fetch services');
+
+    // Second call succeeds
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockServices,
+    });
+
+    // Second refetch - should succeed
+    await act(async () => {
+      result.current.refetch();
+    });
+
+    expect(result.current.services).toEqual(mockServices);
+    expect(result.current.error).toBe(null);
+  });
+
+  it('should handle empty services array', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    });
+
+    const { result } = renderHook(() => useServices());
+
+    await act(async () => {
+      result.current.refetch();
+    });
+
+    expect(result.current.services).toEqual([]);
+    expect(result.current.error).toBe(null);
+  });
+
+  it('should not auto-fetch on initial render', () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    });
+
+    const { result } = renderHook(() => useServices());
+
+    // Should not have called fetch on initial render
+    expect(fetch).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.services).toEqual([]);
+    expect(result.current.error).toBe(null);
+  });
+});

--- a/components/FilterButton.js
+++ b/components/FilterButton.js
@@ -1,0 +1,76 @@
+import styled from 'styled-components';
+
+const FilterButton = styled.button`
+  font-family: 'Press Start 2P', 'VT323', monospace;
+  background: var(--retro-accent2);
+  color: var(--retro-bg1);
+  border: 4px solid var(--retro-accent1);
+  border-radius: 0;
+  padding: 0.5rem 1.5rem;
+  font-size: 0.8rem;
+  margin-bottom: 1rem;
+  cursor: pointer;
+  box-shadow:
+    2px 2px 0 var(--retro-accent1),
+    4px 4px 0 var(--retro-bg1);
+  transition:
+    background 0.1s,
+    color 0.1s;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  &:active {
+    background: var(--retro-accent1);
+    color: var(--retro-accent2);
+    box-shadow:
+      1px 1px 0 var(--retro-accent2),
+      2px 2px 0 var(--retro-bg1);
+    transform: translate(1px, 1px);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  /* Light mode */
+  @media (prefers-color-scheme: light) {
+    background: var(--retro-accent1);
+    color: var(--retro-surface);
+    border: 4px solid var(--retro-accent2);
+    box-shadow:
+      2px 2px 0 var(--retro-accent2),
+      4px 4px 0 var(--retro-border);
+
+    &:active {
+      background: var(--retro-accent2);
+      color: var(--retro-touch);
+      box-shadow:
+        1px 1px 0 var(--retro-accent1),
+        2px 2px 0 var(--retro-border);
+      transform: translate(1px, 1px);
+    }
+  }
+`;
+
+const FilterIcon = () => (
+  <svg
+    width="12"
+    height="12"
+    viewBox="0 0 12 12"
+    fill="currentColor"
+    style={{ display: 'inline-block' }}
+  >
+    <path d="M1 2h10v1H1V2zm0 3h3v1H1V5zm0 3h7v1H1V8zm0 3h5v1H1v-1z" />
+  </svg>
+);
+
+const FilterToggleButton = ({ showFilters, onClick, disabled, ...props }) => (
+  <FilterButton onClick={onClick} disabled={disabled} {...props}>
+    <FilterIcon />
+    {showFilters ? 'Hide Filters' : 'Show Filters'}
+  </FilterButton>
+);
+
+export default FilterToggleButton;

--- a/components/ServiceFilters.js
+++ b/components/ServiceFilters.js
@@ -1,0 +1,141 @@
+import React from 'react';
+
+/**
+ * Basic filter UI component to demonstrate the filtering API
+ * This is a simple implementation - can be enhanced with better styling
+ */
+const ServiceFilters = ({
+  availableNamespaces,
+  availableTypes,
+  filters,
+  setFilter,
+  clearFilters,
+  getFilterStats,
+}) => {
+  const stats = getFilterStats();
+
+  const handleNamespaceChange = (namespace) => {
+    const currentNamespaces = filters.namespaces || [];
+    const newNamespaces = currentNamespaces.includes(namespace)
+      ? currentNamespaces.filter((n) => n !== namespace)
+      : [...currentNamespaces, namespace];
+    setFilter('namespaces', newNamespaces);
+  };
+
+  const handleTypeChange = (type) => {
+    const currentTypes = filters.types || [];
+    const newTypes = currentTypes.includes(type)
+      ? currentTypes.filter((t) => t !== type)
+      : [...currentTypes, type];
+    setFilter('types', newTypes);
+  };
+
+  const handleSearchChange = (e) => {
+    setFilter('searchText', e.target.value);
+  };
+
+  if (availableNamespaces.length === 0 && availableTypes.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="service-filters"
+      style={{
+        marginBottom: '20px',
+        padding: '15px',
+        border: '1px solid #ccc',
+        borderRadius: '5px',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: '15px',
+        }}
+      >
+        <h3 style={{ margin: 0 }}>Filters</h3>
+        <div>
+          {stats.hasActiveFilters && (
+            <span style={{ marginRight: '10px', fontSize: '14px' }}>
+              Showing {stats.filteredCount} of {stats.totalServices} services
+            </span>
+          )}
+          {stats.hasActiveFilters && (
+            <button onClick={clearFilters} style={{ padding: '5px 10px', fontSize: '12px' }}>
+              Clear All
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Text Search */}
+      <div style={{ marginBottom: '15px' }}>
+        <label style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}>
+          Search Service Names:
+        </label>
+        <input
+          type="text"
+          value={filters.searchText || ''}
+          onChange={handleSearchChange}
+          placeholder="Search by service name..."
+          style={{ width: '300px', padding: '5px' }}
+        />
+      </div>
+
+      {/* Namespace Filters */}
+      {availableNamespaces.length > 0 && (
+        <div style={{ marginBottom: '15px' }}>
+          <label style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}>
+            Namespaces:
+          </label>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px' }}>
+            {availableNamespaces.map((namespace) => (
+              <label
+                key={namespace}
+                style={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
+              >
+                <input
+                  type="checkbox"
+                  checked={filters.namespaces?.includes(namespace) || false}
+                  onChange={() => handleNamespaceChange(namespace)}
+                  style={{ marginRight: '5px' }}
+                />
+                {namespace}
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Service Type Filters */}
+      {availableTypes.length > 0 && (
+        <div style={{ marginBottom: '15px' }}>
+          <label style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}>
+            Service Types:
+          </label>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px' }}>
+            {availableTypes.map((type) => (
+              <label
+                key={type}
+                style={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
+              >
+                <input
+                  type="checkbox"
+                  checked={filters.types?.includes(type) || false}
+                  onChange={() => handleTypeChange(type)}
+                  style={{ marginRight: '5px' }}
+                />
+                {type}
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ServiceFilters;

--- a/components/ServiceFilters.js
+++ b/components/ServiceFilters.js
@@ -1,4 +1,4 @@
-fimport React from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 /**

--- a/components/ServiceFilters.js
+++ b/components/ServiceFilters.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
 /**
- * Basic filter UI component to demonstrate the filtering API
- * This is a simple implementation - can be enhanced with better styling
+ * Filter UI component for namespace and service type filtering
+ * Filters are applied automatically when checkboxes are clicked
  */
 const ServiceFilters = ({
   availableNamespaces,
@@ -28,10 +28,6 @@ const ServiceFilters = ({
       ? currentTypes.filter((t) => t !== type)
       : [...currentTypes, type];
     setFilter('types', newTypes);
-  };
-
-  const handleSearchChange = (e) => {
-    setFilter('searchText', e.target.value);
   };
 
   if (availableNamespaces.length === 0 && availableTypes.length === 0) {
@@ -69,20 +65,6 @@ const ServiceFilters = ({
             </button>
           )}
         </div>
-      </div>
-
-      {/* Text Search */}
-      <div style={{ marginBottom: '15px' }}>
-        <label style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}>
-          Search Service Names:
-        </label>
-        <input
-          type="text"
-          value={filters.searchText || ''}
-          onChange={handleSearchChange}
-          placeholder="Search by service name..."
-          style={{ width: '300px', padding: '5px' }}
-        />
       </div>
 
       {/* Namespace Filters */}

--- a/components/ServiceFilters.js
+++ b/components/ServiceFilters.js
@@ -1,9 +1,170 @@
-import React from 'react';
+fimport React from 'react';
+import styled from 'styled-components';
 
 /**
  * Filter UI component for namespace and service type filtering
  * Filters are applied automatically when checkboxes are clicked
  */
+const FilterContainer = styled.div`
+  font-family: 'Press Start 2P', 'VT323', monospace;
+  background: var(--retro-surface);
+  color: var(--retro-text);
+  border: 4px solid var(--retro-accent1);
+  border-radius: 0;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+  box-shadow:
+    4px 4px 0 var(--retro-accent1),
+    8px 8px 0 var(--retro-bg1);
+
+  /* Light mode */
+  @media (prefers-color-scheme: light) {
+    background: var(--retro-surface);
+    color: var(--retro-text);
+    border: 6px double var(--retro-border);
+    box-shadow: 0 0 24px var(--retro-accent1);
+  }
+`;
+
+const FilterHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+
+  h3 {
+    margin: 0;
+    color: var(--retro-accent2);
+    font-size: 1rem;
+
+    /* Light mode */
+    @media (prefers-color-scheme: light) {
+      color: var(--retro-accent1);
+    }
+  }
+`;
+
+const FilterStats = styled.span`
+  font-size: 0.7rem;
+  color: var(--retro-accent2);
+  margin-right: 1rem;
+
+  /* Light mode */
+  @media (prefers-color-scheme: light) {
+    color: var(--retro-accent1);
+  }
+`;
+
+const ClearButton = styled.button`
+  font-family: 'Press Start 2P', 'VT323', monospace;
+  background: var(--retro-accent2);
+  color: var(--retro-bg1);
+  border: 2px solid var(--retro-accent1);
+  border-radius: 0;
+  padding: 0.3rem 0.8rem;
+  font-size: 0.6rem;
+  cursor: pointer;
+  box-shadow:
+    2px 2px 0 var(--retro-accent1),
+    4px 4px 0 var(--retro-bg1);
+  transition:
+    background 0.1s,
+    color 0.1s;
+
+  &:active {
+    background: var(--retro-accent1);
+    color: var(--retro-accent2);
+    box-shadow:
+      1px 1px 0 var(--retro-accent2),
+      2px 2px 0 var(--retro-bg1);
+    transform: translate(1px, 1px);
+  }
+
+  /* Light mode */
+  @media (prefers-color-scheme: light) {
+    background: var(--retro-accent1);
+    color: var(--retro-surface);
+    border: 2px solid var(--retro-accent2);
+    box-shadow:
+      2px 2px 0 var(--retro-accent2),
+      4px 4px 0 var(--retro-border);
+
+    &:active {
+      background: var(--retro-accent2);
+      color: var(--retro-touch);
+      box-shadow:
+        1px 1px 0 var(--retro-accent1),
+        2px 2px 0 var(--retro-border);
+    }
+  }
+`;
+
+const FilterSection = styled.div`
+  margin-bottom: 1.5rem;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  label {
+    display: block;
+    margin-bottom: 0.8rem;
+    font-weight: bold;
+    color: var(--retro-accent2);
+    font-size: 0.8rem;
+
+    /* Light mode */
+    @media (prefers-color-scheme: light) {
+      color: var(--retro-accent1);
+    }
+  }
+`;
+
+const CheckboxGroup = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+`;
+
+const CheckboxLabel = styled.label`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  font-size: 0.7rem;
+  color: var(--retro-text);
+  background: var(--retro-bg1);
+  border: 2px solid var(--retro-accent2);
+  padding: 0.4rem 0.8rem;
+  box-shadow:
+    2px 2px 0 var(--retro-accent1),
+    4px 4px 0 var(--retro-bg1);
+  transition:
+    background 0.1s,
+    border-color 0.1s;
+
+  &:hover {
+    border-color: var(--retro-accent1);
+  }
+
+  input[type='checkbox'] {
+    margin-right: 0.5rem;
+    cursor: pointer;
+  }
+
+  /* Light mode */
+  @media (prefers-color-scheme: light) {
+    background: var(--retro-surface);
+    border: 2px solid var(--retro-border);
+    box-shadow:
+      2px 2px 0 var(--retro-bg2),
+      4px 4px 0 var(--retro-bg1);
+
+    &:hover {
+      border-color: var(--retro-accent1);
+    }
+  }
+`;
+
 const ServiceFilters = ({
   availableNamespaces,
   availableTypes,
@@ -35,88 +196,57 @@ const ServiceFilters = ({
   }
 
   return (
-    <div
-      className="service-filters"
-      style={{
-        marginBottom: '20px',
-        padding: '15px',
-        border: '1px solid #ccc',
-        borderRadius: '5px',
-      }}
-    >
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          marginBottom: '15px',
-        }}
-      >
-        <h3 style={{ margin: 0 }}>Filters</h3>
+    <FilterContainer>
+      <FilterHeader>
+        <h3>FILTERS</h3>
         <div>
           {stats.hasActiveFilters && (
-            <span style={{ marginRight: '10px', fontSize: '14px' }}>
-              Showing {stats.filteredCount} of {stats.totalServices} services
-            </span>
+            <FilterStats>
+              {stats.filteredCount} / {stats.totalServices} SERVICES
+            </FilterStats>
           )}
-          {stats.hasActiveFilters && (
-            <button onClick={clearFilters} style={{ padding: '5px 10px', fontSize: '12px' }}>
-              Clear All
-            </button>
-          )}
+          {stats.hasActiveFilters && <ClearButton onClick={clearFilters}>CLEAR ALL</ClearButton>}
         </div>
-      </div>
+      </FilterHeader>
 
       {/* Namespace Filters */}
       {availableNamespaces.length > 0 && (
-        <div style={{ marginBottom: '15px' }}>
-          <label style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}>
-            Namespaces:
-          </label>
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px' }}>
+        <FilterSection>
+          <label>NAMESPACES:</label>
+          <CheckboxGroup>
             {availableNamespaces.map((namespace) => (
-              <label
-                key={namespace}
-                style={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
-              >
+              <CheckboxLabel key={namespace}>
                 <input
                   type="checkbox"
                   checked={filters.namespaces?.includes(namespace) || false}
                   onChange={() => handleNamespaceChange(namespace)}
-                  style={{ marginRight: '5px' }}
                 />
                 {namespace}
-              </label>
+              </CheckboxLabel>
             ))}
-          </div>
-        </div>
+          </CheckboxGroup>
+        </FilterSection>
       )}
 
       {/* Service Type Filters */}
       {availableTypes.length > 0 && (
-        <div style={{ marginBottom: '15px' }}>
-          <label style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}>
-            Service Types:
-          </label>
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px' }}>
+        <FilterSection>
+          <label>SERVICE TYPES:</label>
+          <CheckboxGroup>
             {availableTypes.map((type) => (
-              <label
-                key={type}
-                style={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
-              >
+              <CheckboxLabel key={type}>
                 <input
                   type="checkbox"
                   checked={filters.types?.includes(type) || false}
                   onChange={() => handleTypeChange(type)}
-                  style={{ marginRight: '5px' }}
                 />
                 {type}
-              </label>
+              </CheckboxLabel>
             ))}
-          </div>
-        </div>
+          </CheckboxGroup>
+        </FilterSection>
       )}
-    </div>
+    </FilterContainer>
   );
 };
 

--- a/components/ServicesTable.js
+++ b/components/ServicesTable.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import ServiceLink from './ServiceLink';
+
+const ServicesTable = ({ services, nodes, loading }) => {
+  return (
+    <div className="retro-table-container">
+      <table className="retro-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Namespace</th>
+            <th>Type</th>
+            <th>ClusterIP</th>
+            <th>Ports</th>
+            <th>Link</th>
+          </tr>
+        </thead>
+        <tbody>
+          {services.length === 0 && !loading ? (
+            <tr>
+              <td colSpan="6" style={{ textAlign: 'center' }}>
+                No services loaded
+              </td>
+            </tr>
+          ) : (
+            services.map((svc, idx) => (
+              <tr key={svc.metadata.name + idx}>
+                <td>{svc.metadata.labels?.['app.kubernetes.io/name'] || svc.metadata.name}</td>
+                <td>{svc.metadata.namespace}</td>
+                <td>{svc.spec.type}</td>
+                <td>{svc.spec.clusterIP}</td>
+                <td>
+                  {svc.spec.ports.map((p, i) => (
+                    <span
+                      key={i}
+                      style={{ display: 'inline-flex', alignItems: 'center', gap: '0.2em' }}
+                    >
+                      {p.port}/{p.protocol}
+                      {p.nodePort ? ` (NodePort: ${p.nodePort})` : ''}
+                      {i < svc.spec.ports.length - 1 ? ', ' : ''}
+                    </span>
+                  ))}
+                </td>
+                <td>
+                  <ServiceLink service={svc} nodes={nodes} />
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default ServicesTable;

--- a/components/ServicesTable.js
+++ b/components/ServicesTable.js
@@ -23,8 +23,8 @@ const ServicesTable = ({ services, nodes, loading }) => {
               </td>
             </tr>
           ) : (
-            services.map((svc, idx) => (
-              <tr key={svc.metadata.name + idx}>
+            services.map((svc) => (
+              <tr key={svc.metadata.uid || `${svc.metadata.namespace}/${svc.metadata.name}`}>
                 <td>{svc.metadata.labels?.['app.kubernetes.io/name'] || svc.metadata.name}</td>
                 <td>{svc.metadata.namespace}</td>
                 <td>{svc.spec.type}</td>

--- a/hooks/useServiceFilters.js
+++ b/hooks/useServiceFilters.js
@@ -1,0 +1,169 @@
+import { useState, useMemo, useCallback } from 'react';
+
+/**
+ * Generic filtering hook for Kubernetes services
+ * Supports namespace, service type, and text search filtering
+ */
+export const useServiceFilters = (services = []) => {
+  const [filters, setFilters] = useState({
+    namespaces: [],
+    types: [],
+    searchText: '',
+  });
+
+  /**
+   * Apply filters to services array
+   * All filters are combined with AND logic
+   */
+  const filteredServices = useMemo(() => {
+    if (!Array.isArray(services)) return [];
+
+    return services.filter((service) => {
+      // Namespace filter
+      if (filters.namespaces.length > 0) {
+        const serviceNamespace = service.metadata?.namespace;
+        if (!serviceNamespace || !filters.namespaces.includes(serviceNamespace)) {
+          return false;
+        }
+      }
+
+      // Service type filter
+      if (filters.types.length > 0) {
+        const serviceType = service.spec?.type;
+        if (!serviceType || !filters.types.includes(serviceType)) {
+          return false;
+        }
+      }
+
+      // Text search filter (case-insensitive)
+      if (filters.searchText && filters.searchText.trim()) {
+        const searchTerm = filters.searchText.toLowerCase().trim();
+        const serviceName = service.metadata?.name?.toLowerCase() || '';
+        const appLabel = service.metadata?.labels?.['app.kubernetes.io/name']?.toLowerCase() || '';
+
+        if (!serviceName.includes(searchTerm) && !appLabel.includes(searchTerm)) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }, [services, filters]);
+
+  /**
+   * Get available namespaces from services
+   */
+  const availableNamespaces = useMemo(() => {
+    if (!Array.isArray(services)) return [];
+    const namespaces = new Set();
+    services.forEach((service) => {
+      if (service.metadata?.namespace) {
+        namespaces.add(service.metadata.namespace);
+      }
+    });
+    return Array.from(namespaces).sort();
+  }, [services]);
+
+  /**
+   * Get available service types from services
+   */
+  const availableTypes = useMemo(() => {
+    if (!Array.isArray(services)) return [];
+    const types = new Set();
+    services.forEach((service) => {
+      if (service.spec?.type) {
+        types.add(service.spec.type);
+      }
+    });
+    return Array.from(types).sort();
+  }, [services]);
+
+  /**
+   * Update a specific filter
+   */
+  const setFilter = useCallback((filterType, value) => {
+    setFilters((prev) => ({
+      ...prev,
+      [filterType]: value,
+    }));
+  }, []);
+
+  /**
+   * Set multiple filters at once
+   */
+  const updateFilters = useCallback((newFilters) => {
+    setFilters(newFilters);
+  }, []);
+
+  /**
+   * Clear all filters
+   */
+  const clearFilters = useCallback(() => {
+    setFilters({
+      namespaces: [],
+      types: [],
+      searchText: '',
+    });
+  }, []);
+
+  /**
+   * Clear a specific filter
+   */
+  const clearFilter = useCallback((filterType) => {
+    setFilters((prev) => ({
+      ...prev,
+      [filterType]: filterType === 'searchText' ? '' : [],
+    }));
+  }, []);
+
+  /**
+   * Get filter statistics
+   */
+  const getFilterStats = useCallback(() => {
+    const totalServices = Array.isArray(services) ? services.length : 0;
+    const filteredCount = filteredServices.length;
+    const activeFiltersCount = [
+      filters.namespaces.length > 0,
+      filters.types.length > 0,
+      filters.searchText && filters.searchText.trim().length > 0,
+    ].filter(Boolean).length;
+
+    return {
+      totalServices,
+      filteredCount,
+      activeFiltersCount,
+      hasActiveFilters: activeFiltersCount > 0,
+      isFiltered: filteredCount < totalServices,
+    };
+  }, [services, filteredServices.length, filters]);
+
+  /**
+   * Check if a service matches current filters
+   */
+  const serviceMatchesFilters = useCallback(
+    (service) => {
+      return filteredServices.includes(service);
+    },
+    [filteredServices]
+  );
+
+  return {
+    // Data
+    filteredServices,
+    availableNamespaces,
+    availableTypes,
+
+    // Filter state
+    filters,
+
+    // Filter actions
+    setFilter,
+    updateFilters,
+    clearFilters,
+    clearFilter,
+
+    // Utilities
+    getFilterStats,
+    serviceMatchesFilters,
+  };
+};

--- a/hooks/useServices.js
+++ b/hooks/useServices.js
@@ -1,0 +1,32 @@
+import { useState, useCallback } from 'react';
+
+export const useServices = () => {
+  const [services, setServices] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchServices = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/services');
+      if (!response.ok) {
+        throw new Error('Failed to fetch services');
+      }
+      const data = await response.json();
+      setServices(data);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return {
+    services,
+    loading,
+    error,
+    refetch: fetchServices,
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodeporter",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodeporter",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "license": "ISC",
       "dependencies": {
         "@fastify/cors": "11.2.0",

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,12 +5,22 @@ import Button from '../components/Button';
 import Error from '../components/Error';
 import ClusterSummary from '../components/ClusterSummary';
 import ServicesTable from '../components/ServicesTable';
+import ServiceFilters from '../components/ServiceFilters';
+import FilterButton from '../components/FilterButton';
 import { useServices } from '../hooks/useServices';
 import { useServiceFilters } from '../hooks/useServiceFilters';
 
 export default function Home() {
   const { services, loading, error, refetch: refetchServices } = useServices();
-  const { filteredServices } = useServiceFilters(services);
+  const {
+    filteredServices,
+    availableNamespaces,
+    availableTypes,
+    filters,
+    setFilter,
+    clearFilters,
+    getFilterStats,
+  } = useServiceFilters(services);
   const [nodes, setNodes] = useState([]);
   const [nodeSummary, setNodeSummary] = useState(null);
   const [nodesError, setNodesError] = useState(null);
@@ -18,6 +28,7 @@ export default function Home() {
   const [envType, setEnvType] = useState(null);
   const [hasLoaded, setHasLoaded] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [showFilters, setShowFilters] = useState(false);
 
   React.useEffect(() => {
     fetch('/api/envtype')
@@ -115,6 +126,23 @@ export default function Home() {
         </ClusterSummary>
       )}
       {error && <Error>{error}</Error>}
+      {(availableNamespaces.length > 0 || availableTypes.length > 0) && (
+        <FilterButton
+          showFilters={showFilters}
+          onClick={() => setShowFilters(!showFilters)}
+          disabled={refreshing}
+        />
+      )}
+      {showFilters && (
+        <ServiceFilters
+          availableNamespaces={availableNamespaces}
+          availableTypes={availableTypes}
+          filters={filters}
+          setFilter={setFilter}
+          clearFilters={clearFilters}
+          getFilterStats={getFilterStats}
+        />
+      )}
       <ServicesTable services={filteredServices} nodes={nodes} loading={loading} />
       <FetchTime fetchTime={fetchTime} />
     </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,9 +6,11 @@ import Error from '../components/Error';
 import ClusterSummary from '../components/ClusterSummary';
 import ServicesTable from '../components/ServicesTable';
 import { useServices } from '../hooks/useServices';
+import { useServiceFilters } from '../hooks/useServiceFilters';
 
 export default function Home() {
   const { services, loading, error, refetch: refetchServices } = useServices();
+  const { filteredServices } = useServiceFilters(services);
   const [nodes, setNodes] = useState([]);
   const [nodeSummary, setNodeSummary] = useState(null);
   const [nodesError, setNodesError] = useState(null);
@@ -113,7 +115,7 @@ export default function Home() {
         </ClusterSummary>
       )}
       {error && <Error>{error}</Error>}
-      <ServicesTable services={services} nodes={nodes} loading={loading} />
+      <ServicesTable services={filteredServices} nodes={nodes} loading={loading} />
       <FetchTime fetchTime={fetchTime} />
     </div>
   );

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,17 +1,16 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import FetchTime from '../components/FetchTime';
 import EnvironmentBanner from '../components/EnvironmentBanner';
 import Button from '../components/Button';
 import Error from '../components/Error';
 import ClusterSummary from '../components/ClusterSummary';
-import ServiceLink from '../components/ServiceLink';
+import ServicesTable from '../components/ServicesTable';
+import { useServices } from '../hooks/useServices';
 
 export default function Home() {
-  const [services, setServices] = useState([]);
+  const { services, loading, error, refetch: refetchServices } = useServices();
   const [nodes, setNodes] = useState([]);
   const [nodeSummary, setNodeSummary] = useState(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
   const [nodesError, setNodesError] = useState(null);
   const [fetchTime, setFetchTime] = useState(null);
   const [envType, setEnvType] = useState(null);
@@ -24,21 +23,12 @@ export default function Home() {
       .catch(() => setEnvType('unknown'));
   }, []);
 
-  const fetchKubernetesData = async () => {
-    setLoading(true);
-    setError(null);
+  const fetchKubernetesData = useCallback(async () => {
     setNodesError(null);
     setFetchTime(null);
     const start = performance.now();
-    // Run both fetches in parallel
-    const servicesPromise = fetch('/api/services')
-      .then((response) => {
-        if (!response.ok) throw new Error('Failed to fetch services');
-        return response.json();
-      })
-      .then(setServices)
-      .catch((err) => setError(err.message));
 
+    // Fetch nodes data only (services are handled by useServices hook)
     const nodesPromise = fetch('/api/nodes')
       .then((response) => {
         if (!response.ok) throw new Error('Failed to fetch nodes');
@@ -84,17 +74,19 @@ export default function Home() {
         setNodesError(err.message);
       });
 
-    await Promise.all([servicesPromise, nodesPromise]);
+    // Fetch services data using the hook's refetch function
+    const servicesPromise = refetchServices();
+
+    await Promise.all([nodesPromise, servicesPromise]);
     const elapsed = performance.now() - start;
     setFetchTime(elapsed);
-    setLoading(false);
-  };
+  }, [refetchServices]);
 
   React.useEffect(() => {
     // Auto-load data on component mount
     fetchKubernetesData();
     setHasLoaded(true);
-  }, []);
+  }, [fetchKubernetesData]);
 
   return (
     <div className="retro-8bit-app">
@@ -115,53 +107,7 @@ export default function Home() {
         </ClusterSummary>
       )}
       {error && <Error>{error}</Error>}
-      <div className="retro-table-container">
-        <table className="retro-table">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Namespace</th>
-              <th>Type</th>
-              <th>ClusterIP</th>
-              <th>Ports</th>
-              <th>Link</th>
-            </tr>
-          </thead>
-          <tbody>
-            {services.length === 0 && !loading ? (
-              <tr>
-                <td colSpan="6" style={{ textAlign: 'center' }}>
-                  No services loaded
-                </td>
-              </tr>
-            ) : (
-              services.map((svc, idx) => (
-                <tr key={svc.metadata.name + idx}>
-                  <td>{svc.metadata.labels?.['app.kubernetes.io/name'] || svc.metadata.name}</td>
-                  <td>{svc.metadata.namespace}</td>
-                  <td>{svc.spec.type}</td>
-                  <td>{svc.spec.clusterIP}</td>
-                  <td>
-                    {svc.spec.ports.map((p, i) => (
-                      <span
-                        key={i}
-                        style={{ display: 'inline-flex', alignItems: 'center', gap: '0.2em' }}
-                      >
-                        {p.port}/{p.protocol}
-                        {p.nodePort ? ` (NodePort: ${p.nodePort})` : ''}
-                        {i < svc.spec.ports.length - 1 ? ', ' : ''}
-                      </span>
-                    ))}
-                  </td>
-                  <td>
-                    <ServiceLink service={svc} nodes={nodes} />
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
+      <ServicesTable services={services} nodes={nodes} loading={loading} />
       <FetchTime fetchTime={fetchTime} />
     </div>
   );

--- a/pages/index.js
+++ b/pages/index.js
@@ -15,6 +15,7 @@ export default function Home() {
   const [fetchTime, setFetchTime] = useState(null);
   const [envType, setEnvType] = useState(null);
   const [hasLoaded, setHasLoaded] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
 
   React.useEffect(() => {
     fetch('/api/envtype')
@@ -24,6 +25,7 @@ export default function Home() {
   }, []);
 
   const fetchKubernetesData = useCallback(async () => {
+    setRefreshing(true);
     setNodesError(null);
     setFetchTime(null);
     const start = performance.now();
@@ -77,9 +79,13 @@ export default function Home() {
     // Fetch services data using the hook's refetch function
     const servicesPromise = refetchServices();
 
-    await Promise.all([nodesPromise, servicesPromise]);
-    const elapsed = performance.now() - start;
-    setFetchTime(elapsed);
+    try {
+      await Promise.all([nodesPromise, servicesPromise]);
+      const elapsed = performance.now() - start;
+      setFetchTime(elapsed);
+    } finally {
+      setRefreshing(false);
+    }
   }, [refetchServices]);
 
   React.useEffect(() => {
@@ -94,8 +100,8 @@ export default function Home() {
       <EnvironmentBanner envType={envType} />
       <h1 className="retro-title">K8s Service Table</h1>
       {hasLoaded && (
-        <Button onClick={fetchKubernetesData} disabled={loading}>
-          {loading ? 'Loading...' : 'Refresh'}
+        <Button onClick={fetchKubernetesData} disabled={refreshing}>
+          {refreshing ? 'Loading...' : 'Refresh'}
         </Button>
       )}
       {nodesError && <Error>Nodes error: {nodesError}</Error>}


### PR DESCRIPTION
This pull request refactors the way Kubernetes services are fetched and displayed in the application. It introduces a new custom hook for fetching services, moves the services table to its own component, and adds comprehensive tests for both. The main goal is to improve modularity, testability, and code clarity around service data fetching and presentation.

**Services fetching and state management improvements:**

- Introduced a new custom hook `useServices` in `hooks/useServices.js` to encapsulate fetching, loading, and error state for Kubernetes services, providing a `refetch` method for manual refresh.
- Updated the main page (`pages/index.js`) to use the new `useServices` hook, removing direct fetch logic and related state from the component. The services fetch is now handled via the hook, and the main fetch function only fetches nodes and triggers the hook's refetch. [[1]](diffhunk://#diff-7c97c1ad17c63f34774324965f81661cea32f533a65c39ab03576069972e4d0eL1-L14) [[2]](diffhunk://#diff-7c97c1ad17c63f34774324965f81661cea32f533a65c39ab03576069972e4d0eL27-R31) [[3]](diffhunk://#diff-7c97c1ad17c63f34774324965f81661cea32f533a65c39ab03576069972e4d0eL87-R89)

**Componentization and UI improvements:**

- Extracted the services table into a new reusable `ServicesTable` component (`components/ServicesTable.js`), removing table markup from `pages/index.js` and improving separation of concerns. [[1]](diffhunk://#diff-4b987f30bcb1562d01f8bf58db080fff22f9f4af0b9add74da483c39c812dd4bR1-R56) [[2]](diffhunk://#diff-7c97c1ad17c63f34774324965f81661cea32f533a65c39ab03576069972e4d0eL118-R110)

**Testing enhancements:**

- Added comprehensive unit tests for the new `useServices` hook in `__tests__/hooks/useServices.test.js`, covering successful fetches, errors, JSON parsing issues, and state resets.
- Added detailed tests for the new `ServicesTable` component in `__tests__/components/ServicesTable.test.js`, verifying correct rendering of service data, headers, and edge cases.